### PR TITLE
[NICHT ZUSAMMENFÜHREN] Nur für die Nutzung im DevOps-Center – Integration zu QA

### DIFF
--- a/force-app/main/default/flexipages/Teilobjekt_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Teilobjekt_Record_Page.flexipage-meta.xml
@@ -552,6 +552,16 @@
                 <identifier>RecordVerkaufsprovision_cField</identifier>
             </fieldInstance>
         </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.ClosingBonus__c</fieldItem>
+                <identifier>RecordClosingBonus_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
         <name>Facet-f636b300-8ab1-4876-b29f-96e41d02a052</name>
         <type>Facet</type>
     </flexiPageRegions>


### PR DESCRIPTION
Die vom DevOps-Center erstellte Pull-Anforderung soll nur für das DevOps-Center verwendet werden. Aufgrund potenzieller Datenbeschädigung sollten Sie diese Pull-Anforderung in GitHub NICHT ZUSAMMENFÜHREN.