### PR TITLE
[NICHT ZUSAMMENFÜHREN] Nur für die Nutzung im DevOps-Center – Integration zu QA

### DIFF
--- a/force-app/main/default/classes/RestTeamProQOpportunity.cls
+++ b/force-app/main/default/classes/RestTeamProQOpportunity.cls
@@ -103,6 +103,7 @@ global without sharing class RestTeamProQOpportunity {
         opp.CloseDate = Date.today().addMonths(3);
         opp.SourceCreation__c = 'TeamProQ';
         opp.KfwWunsch__c = 'Kein KfW';
+        opp.TeamProQId__c = data.teamProQId;
 
         // Fill in text area fields so that information can be checked 
         // or contacts can be created manually 
@@ -197,6 +198,7 @@ global without sharing class RestTeamProQOpportunity {
     global class RestTeamProQOpportunityRequest {
         global String propertyExternalId;
         global String apartmentExternalId;
+        global String teamProQId;
         global Id accountId;
         global Contact firstBuyer;
         global Contact secondBuyer;

--- a/force-app/main/default/customindex/Opportunity.TeamProQId__c.indx-meta.xml
+++ b/force-app/main/default/customindex/Opportunity.TeamProQId__c.indx-meta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomIndex xmlns="http://soap.sforce.com/2006/04/metadata">
+    <allowNullValues>false</allowNullValues>
+</CustomIndex>

--- a/force-app/main/default/objects/Opportunity/fields/TeamProQId__c.field-meta.xml
+++ b/force-app/main/default/objects/Opportunity/fields/TeamProQId__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TeamProQId__c</fullName>
+    <caseSensitive>false</caseSensitive>
+    <externalId>true</externalId>
+    <label>TeamProQ ID</label>
+    <length>25</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>true</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/TeamProQ_Integration.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/TeamProQ_Integration.permissionset-meta.xml
@@ -691,6 +691,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Opportunity.TeamProQId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Opportunity.beurkundeter_Kaufpreis__c</field>
         <readable>true</readable>


### PR DESCRIPTION
Die vom DevOps-Center erstellte Pull-Anforderung soll nur für das DevOps-Center verwendet werden. Aufgrund potenzieller Datenbeschädigung sollten Sie diese Pull-Anforderung in GitHub NICHT ZUSAMMENFÜHREN.