### PR TITLE
[NICHT ZUSAMMENFÜHREN] Nur für die Nutzung im DevOps-Center – Integration zu QA

### DIFF
--- a/force-app/main/default/flows/Berechnung_after_insert_update.flow-meta.xml
+++ b/force-app/main/default/flows/Berechnung_after_insert_update.flow-meta.xml
@@ -11,7 +11,7 @@
         <inputParameters>
             <name>customNotifTypeId</name>
             <value>
-                <stringValue>0ML3O0000000V2LWAU</stringValue>
+                <stringValue>0ML670000004CVRGA2</stringValue>
             </value>
         </inputParameters>
         <inputParameters>


### PR DESCRIPTION
Die vom DevOps-Center erstellte Pull-Anforderung soll nur für das DevOps-Center verwendet werden. Aufgrund potenzieller Datenbeschädigung sollten Sie diese Pull-Anforderung in GitHub NICHT ZUSAMMENFÜHREN.