### PR TITLE
[NICHT ZUSAMMENFÜHREN] Nur für die Nutzung im DevOps-Center – Integration zu QA

### DIFF
--- a/force-app/main/default/classes/ScheduledOposSync.cls
+++ b/force-app/main/default/classes/ScheduledOposSync.cls
@@ -115,9 +115,9 @@ global without sharing class ScheduledOposSync implements Schedulable {
         List<VkcZahlung__c> vkcZahlungen = new List<VkcZahlung__c>();
         for(Opportunity opp:opps) {
             if(opp.Immobilie__r.Name == 'Essen-Kettwig – Pflege') {
-                rechnungsNummerAddition += 'PF';
+                rechnungsNummerAddition = 'PF';
             } else if(opp.Immobilie__r.Name == 'Essen-Kettwig – Betreutes Wohnen') {
-                rechnungsNummerAddition += 'BW';
+                rechnungsNummerAddition = 'BW';
             }
             String rechnungsNummer = opp.Immobilie__r.Objektnummer__c + '-' + opp.Appartement__r.ApartmentNummer__c + rechnungsNummerAddition;
             List<Opos> oposList = rechnungsNummerToOpos.get(rechnungsNummer);


### PR DESCRIPTION
Die vom DevOps-Center erstellte Pull-Anforderung soll nur für das DevOps-Center verwendet werden. Aufgrund potenzieller Datenbeschädigung sollten Sie diese Pull-Anforderung in GitHub NICHT ZUSAMMENFÜHREN.