### PR TITLE
[NICHT ZUSAMMENFÜHREN] Nur für die Nutzung im DevOps-Center – Integration zu QA

### DIFF
--- a/force-app/main/default/classes/ImmobilienController.cls
+++ b/force-app/main/default/classes/ImmobilienController.cls
@@ -144,6 +144,9 @@ public without sharing class ImmobilienController {
                 }
             }
             immosByIds.put(property.Id, i);
+            for(Appartment__c teilobjekt : property.Appartments__r) {
+                immosByIds.get(teilobjekt.Property__c).teilobjekte.add(teilobjekt);
+            }
         }
 
         return immosByIds.values();


### PR DESCRIPTION
Die vom DevOps-Center erstellte Pull-Anforderung soll nur für das DevOps-Center verwendet werden. Aufgrund potenzieller Datenbeschädigung sollten Sie diese Pull-Anforderung in GitHub NICHT ZUSAMMENFÜHREN.