### PR TITLE
[NICHT ZUSAMMENFÜHREN] Nur für die Nutzung im DevOps-Center – Integration zu QA

### DIFF
--- a/force-app/main/default/classes/ImmobilienControllerTest.cls
+++ b/force-app/main/default/classes/ImmobilienControllerTest.cls
@@ -101,6 +101,9 @@ public with sharing class ImmobilienControllerTest {
         immobilie.Website__c = 'www.test.de';
         immobilie.Arrival__c = Date.today();
         insert immobilie;
+
+        TestDataFactory.createImmobilienDMSDatei(true, immobilie.Id, 'Dokumente');
+        TestDataFactory.createImmobilienDMSDatei(true, immobilie.Id, 'Bilder');
         
         List<Appartment__c> apps = new List<Appartment__c>();
         for(Integer i = 0; i < 5; i++) {


### PR DESCRIPTION
Die vom DevOps-Center erstellte Pull-Anforderung soll nur für das DevOps-Center verwendet werden. Aufgrund potenzieller Datenbeschädigung sollten Sie diese Pull-Anforderung in GitHub NICHT ZUSAMMENFÜHREN.